### PR TITLE
PSS-452: API. Can't add liquidity if it was already in the network and was deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.6",
+  "version": "0.4.7",
   "author": "Stefan Popov <popov@soramitsu.co.jp>",
   "private": true,
   "scripts": {

--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@sora-substrate/api-derive",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./build/index.js",
   "typings": "./build/index.d.ts",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@sora-substrate/types": "^0.4.6",
+    "@sora-substrate/types": "^0.4.7",
     "@babel/runtime": "^7.10.2",
     "@polkadot/api-derive": "^2.1.2-8",
     "rxjs": "^6.5.5"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@sora-substrate/api",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./build/index.js",
   "typings": "./build/index.d.ts",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@sora-substrate/types": "^0.4.6",
-    "@sora-substrate/api-derive": "^0.4.6",
+    "@sora-substrate/types": "^0.4.7",
+    "@sora-substrate/api-derive": "^0.4.7",
     "@babel/runtime": "^7.10.2",
     "@open-web3/orml-api-derive": "^0.6.0-beta.26",
     "@polkadot/api": "^2.1.2-8",

--- a/packages/type-definitions/package.json
+++ b/packages/type-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sora-substrate/type-definitions",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./build/index.js",
   "typings": "./build/index.d.ts",
   "publishConfig": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@sora-substrate/types",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./build/index.js",
   "typings": "./build/index.d.ts",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@sora-substrate/type-definitions": "^0.4.6",
+    "@sora-substrate/type-definitions": "^0.4.7",
     "@babel/runtime": "^7.10.2",
     "@open-web3/api-mobx": "^0.6.0-beta.26",
     "@open-web3/orml-types": "^0.6.0-beta.26",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sora-substrate/util",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./build/index.js",
   "typings": "./build/index.d.ts",
   "publishConfig": {
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@polkadot/ui-keyring": "^0.61.1",
-    "@sora-substrate/api": "^0.4.6",
+    "@sora-substrate/api": "^0.4.7",
     "bignumber.js": "^9.0.1",
     "crypto-js": "^4.0.0",
     "lodash": "^4.17.15"

--- a/packages/util/src/api.ts
+++ b/packages/util/src/api.ts
@@ -704,7 +704,7 @@ export class Api extends BaseApi {
     const secondAsset = await this.getAssetInfo(secondAssetAddress)
     const firstValue = new FPNumber(result[0], firstAsset.decimals)
     const secondValue = new FPNumber(result[1], secondAsset.decimals)
-    return [firstValue.toString(), secondValue.toString()]
+    return [firstValue.toString(FPNumber.DEFAULT_PRECISION), secondValue.toString(FPNumber.DEFAULT_PRECISION)]
   }
 
   /**


### PR DESCRIPTION
# Task

[PSS-452]: API. Can't add liquidity if it was already in the network and was deleted.

## Changes

* Fixed Get Liquidity Reserves function and updated packages versions.

## Author

Signed-off-by: alexnatalia <alekseenko@soramitsu.co.jp>

[PSS-452]: https://soramitsu.atlassian.net/browse/PSS-452